### PR TITLE
Make actor's moving and die more controllable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
+# https://github.com/marketplace/actions/release-drafter
 name: Release Drafter
 
 on:
   push:
+    # branches to consider in the event; optional, defaults to all
     branches:
-      - main
+      - master
+  # pull_request event is required only for autolabeler
   pull_request:
+    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -13,10 +20,23 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write  # for release-drafter/release-drafter to create a github release
-      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+<a id='changelog-0.5.3'></a>
+# 0.5.3 — 2024-03-26
+
+## Fixed bugs
+
+- [x] #bug🐛 Only alive actors can apply default methods by decorator `alive_required` now.
+- [x] #bug🐛 now moving has a return to control continue to move or not.
+- [x] #bug🐛 now update the position attribute correctly after moving
+- [x] #bug🐛 fixing release drafter to the latest version
+
 <a id='changelog-0.5.2'></a>
 # 0.5.2 — 2024-03-26
 

--- a/abses/__init__.py
+++ b/abses/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
     "alive_required",
     "time_condition",
 ]
-__version__ = "v0.5.2"
+__version__ = "v0.5.3"
 
 from .actor import Actor, alive_required, perception
 from .container import ActorsList

--- a/abses/__init__.py
+++ b/abses/__init__.py
@@ -25,10 +25,12 @@ __all__ = [
     "ActorsList",
     "PatchCell",
     "perception",
+    "alive_required",
+    "time_condition",
 ]
 __version__ = "v0.5.2"
 
-from .actor import Actor, perception
+from .actor import Actor, alive_required, perception
 from .container import ActorsList
 from .decision import Decision
 from .human import BaseHuman

--- a/abses/actor.py
+++ b/abses/actor.py
@@ -192,6 +192,7 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
                 "Cannot set location directly because the actor is not added to the cell."
             )
         self._cell = cell
+        self.pos = cell.pos
 
     @at.deleter
     def at(self) -> None:

--- a/abses/actor.py
+++ b/abses/actor.py
@@ -313,7 +313,8 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         It should be called when the actor is initialized.
         """
 
-    def moving(self, cell: PatchCell) -> None:
+    def moving(self, cell: PatchCell) -> Optional[bool]:
         """Overwrite this method.
         It should be called when the actor is moved.
+        The return value is whether the actor can move to the cell.
         """

--- a/abses/actor.py
+++ b/abses/actor.py
@@ -52,6 +52,18 @@ TARGET_KEYWORDS = {
 }
 
 
+def alive_required(method):
+    """
+    A decorator that only executes the method when the object's alive attribute is True.
+    """
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs) -> Any:
+        return method(self, *args, **kwargs) if self.alive else None
+
+    return wrapper
+
+
 def perception_result(name, result, nodata: Any = 0.0) -> Any:
     """clean the result of a perception.
 
@@ -149,6 +161,7 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         _LinkNode.__init__(self)
         self._cell: PatchCell = None
         self._decisions: _DecisionFactory = self._setup_decisions()
+        self._alive: bool = True
         self._setup()
 
     def __repr__(self) -> str:
@@ -158,6 +171,11 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         """Decisions that this actor makes."""
         decisions = make_list(getattr(self, "__decisions__", None))
         return _DecisionFactory(self, decisions)
+
+    @property
+    def alive(self) -> bool:
+        """Whether the actor is alive."""
+        return self._alive
 
     @property
     def decisions(self) -> _DecisionFactory:
@@ -245,6 +263,7 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         warn = "Set a new attribute outside '__init__' is not allowed."
         raise AttributeError(f"Attribute '{attr}' not found in {self}. {warn}")
 
+    @alive_required
     def get(
         self,
         attr: str,
@@ -267,6 +286,7 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         target = self._get_correct_target(target, attr=attr)
         return getattr(self, attr) if target is self else target.get(attr)
 
+    @alive_required
     def set(self, attr: str, value: Any, target: Targets) -> None:
         """Sets the value of an attribute.
 
@@ -296,12 +316,14 @@ class Actor(mg.GeoAgent, _BaseObj, _LinkNode):
         target = self._get_correct_target(target=target, attr=attr)
         setattr(target, attr, value)
 
+    @alive_required
     def die(self) -> None:
         """Kills the agent (self)"""
         self.link.clean()  # 从链接中移除
         if self.on_earth:  # 如果在地上，那么从地块上移除
             self.move.off()
         self.model.agents.remove(self)  # 从总模型里移除
+        self._alive = False  # 设置为死亡状态
         del self
 
     def _setup(self) -> None:

--- a/abses/move.py
+++ b/abses/move.py
@@ -66,7 +66,9 @@ def _put_agent_on_cell(agent: Actor, cell: PatchCell) -> None:
     if agent.on_earth:
         agent.move.off()
     # before moving to the new cell, agent may do something
-    agent.moving(cell=cell)
+    keep_moving = agent.moving(cell=cell)
+    if keep_moving is False:
+        return
     # put the agent on the new cell after check.
     cell.agents.add(agent, register=True)
     agent.at = cell

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: "Agent-Based Social-ecological systems Modelling Framework in Pytho
 
 <!-- Language: [English Readme](#) | [简体中文](README_ch) -->
 
-**Date**: January. 11, 2024, **Version**: 0.5.2
+**Date**: January. 11, 2024, **Version**: 0.5.3
 
 **Useful links**: [Install](home/Installation.md) | [Source Repository](https://github.com/ABSESpy/ABSESpy) | [Issues & Ideas](https://github.com/ABSESpy/ABSESpy/issues) | [Q&A Support](https://github.com/ABSESpy/ABSESpy/discussions)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line_length = 79
 
 [tool.poetry]
 name = "abses"
-version = "0.5.2"
+version = "0.5.3"
 description = "ABSESpy makes it easier to build artificial Social-ecological systems with real GeoSpatial datasets and fully incorporate human behaviour."
 authors = ["Shuang Song <songshgeo@gmail.com>"]
 license = "Apache 2.0 License"


### PR DESCRIPTION
## Fixed bugs

- [x] #bug🐛 Only alive actors can apply default methods by decorator `alive_required` now.
- [x] #bug🐛 now moving has a return to control continue to move or not.
- [x] #bug🐛 now update the position attribute correctly after moving
- [x] #bug🐛 fixing release drafter to the latest version
