### PR TITLE
Fix some bugs for setting/getting values and typos in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 
+<a id='changelog-0.5.7'></a>
+# 0.5.7 — 2024-04-10
+
+## Fixed bugs
+
+- [x] #bug🐛 Fixing default getter setter for `ActorsList`, `Actor`, and `PatchCell`
+- [x] #bug🐛  AttributeError when getting value with wrong key
+
+## Documentation changes
+
+- [x] #docs📄 adding authors' ORCID of the paper
+- [x] #docs📄 correcting installation from source tutorial
+- [x] #docs📄  fixing Mantilla Ibarra name and capitalizing refers
+
 <a id='changelog-0.5.6'></a>
 # 0.5.6 — 2024-04-06
 

--- a/abses/__init__.py
+++ b/abses/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
     "alive_required",
     "time_condition",
 ]
-__version__ = "v0.5.6"
+__version__ = "v0.5.7"
 
 from .actor import Actor, alive_required, perception
 from .container import ActorsList

--- a/abses/links.py
+++ b/abses/links.py
@@ -546,11 +546,16 @@ class _LinkNode:
         if target in DEFAULT_TARGETS:
             self._default_redirection(target).set(attr, value)
             return
+        if target is None:
+            if not hasattr(self, attr):
+                raise AttributeError(f"{self} has no attribute '{attr}'.")
+            setattr(self, attr, value)
+            return
         # Set the attribute on the target.
         if hasattr(self, attr):
             assert (
                 target is None
-            ), "The target '{target}' is ignored, because '{self}' already has attr '{attr}'."
+            ), f"The target '{target}' is set when '{self}' already has attr '{attr}'."
             setattr(self, attr, value)
         else:
             new_target = self._redirect_getting(target=target)

--- a/abses/links.py
+++ b/abses/links.py
@@ -507,10 +507,12 @@ class _LinkNode:
         """
         if target in DEFAULT_TARGETS:
             return self._default_redirection(target).get(attr)
+        if target is None:
+            return getattr(self, attr)
         if hasattr(self, attr):
             assert (
                 target is None
-            ), "The target '{target}' is ignored because '{self}' already has attr '{attr}'."
+            ), f"The target '{target}' is set when '{self}' already has attr '{attr}'."
             return getattr(self, attr)
         return self._redirect_getting(target=target).get(attr)
 

--- a/abses/sequences.py
+++ b/abses/sequences.py
@@ -48,7 +48,7 @@ from .tools.func import make_list
 if TYPE_CHECKING:
     from abses.main import MainModel
 
-    from .actor import Actor
+    from .actor import Actor, TargetName
 
 Selection: TypeAlias = Union[str, Iterable[bool], Dict[str, bool]]
 HOW: TypeAlias = Literal["only", "random", "item"]
@@ -280,7 +280,11 @@ class ActorsList(List[ActorType], Generic[ActorType]):
         return np.array(list(map(func, self)))
 
     def get(
-        self, attr: str, how: HOW = "only", default: Optional[Any] = None
+        self,
+        attr: str,
+        target: Optional[TargetName] = None,
+        how: HOW = "only",
+        default: Optional[Any] = None,
     ) -> Any:
         """Retrieve the attribute of an either specified or randomly chosen agent.
 
@@ -294,12 +298,14 @@ class ActorsList(List[ActorType], Generic[ActorType]):
             The attribute of the specified agent.
         """
         if agent := self.item(how=how, index=0):
-            return agent.get(attr)
+            return agent.get(attr, target=target)
         if default is not None:
             return default
         raise ValueError("No agent found or default value.")
 
-    def set(self, attr: str, value: Any) -> None:
+    def set(
+        self, attr: str, value: Any, target: Optional[TargetName] = None
+    ) -> None:
         """Set the attribute of all agents in the sequence to the specified value.
 
         Parameters:
@@ -309,7 +315,7 @@ class ActorsList(List[ActorType], Generic[ActorType]):
                 The value to set the attribute to.
         """
         for agent in iter(self):
-            agent.set(attr, value)
+            agent.set(attr, value, target=target)
 
     def item(self, how: HOW = "item", index: int = 0) -> Optional[Actor]:
         """Retrieve one agent if possible.

--- a/docs/home/Installation.md
+++ b/docs/home/Installation.md
@@ -28,7 +28,7 @@ repository into a subfolder of your project root which might be useful if you
 want to use the very latest version:
 
 ```sh
-git clone https://github.com/ABSESpy/ABSESpy
+git clone https://github.com/ABSESpy/ABSESpy abses
 ```
 
 Next, install the theme and its dependencies with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: "Agent-Based Social-ecological systems Modelling Framework in Pytho
 
 <!-- Language: [English Readme](#) | [简体中文](README_ch) -->
 
-**Date**: January. 11, 2024, **Version**: 0.5.6
+**Date**: January. 11, 2024, **Version**: 0.5.7
 
 **Useful links**: [Install](home/Installation.md) | [Source Repository](https://github.com/ABSESpy/ABSESpy) | [Issues & Ideas](https://github.com/ABSESpy/ABSESpy/issues) | [Q&A Support](https://github.com/ABSESpy/ABSESpy/discussions)
 

--- a/docs/paper/paper.md
+++ b/docs/paper/paper.md
@@ -17,7 +17,7 @@ authors:
 - name: Chentai Jiao
   affiliation: 1
   orcid: 0000-0003-1737-9814
-- name: Elías José Mantilla
+- name: Elías José Mantilla Ibarra
   affiliation: 2
 affiliations:
  - name: Faculty of Geographical Science, Beijing Normal University. 100875, Beijing, China.

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -37,7 +37,7 @@
 }
 
 @article{beckage2022,
-  title = {Incorporating human behaviour into earth system modelling},
+  title = {Incorporating human behaviour into {Earth} system modelling},
   author = {Beckage, Brian and Moore, Frances C. and Lacasse, Katherine},
   year = {2022},
   month = nov,
@@ -298,7 +298,7 @@
 }
 
 @article{reyers2018,
-  title = {Social-Ecological Systems Insights for Navigating the Dynamics of the Anthropocene},
+  title = {Social-Ecological Systems Insights for Navigating the Dynamics of the {Anthropocene}},
   author = {Reyers, Belinda and Folke, Carl and Moore, Michele-Lee and Biggs, Reinette and Galaz, Victor},
   year = {2018},
   month = oct,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line_length = 79
 
 [tool.poetry]
 name = "abses"
-version = "0.5.6"
+version = "0.5.7"
 description = "ABSESpy makes it easier to build artificial Social-ecological systems with real GeoSpatial datasets and fully incorporate human behaviour."
 authors = ["Shuang Song <songshgeo@gmail.com>"]
 license = "Apache 2.0 License"

--- a/tests/api/test_actor.py
+++ b/tests/api/test_actor.py
@@ -85,43 +85,6 @@ class TestActor:
         assert len(model.agents) == 0
 
     @pytest.mark.parametrize(
-        "attr, target, expected",
-        [
-            ("test2", None, 3),
-            ("test2", "actor", 3),
-            ("test2", "cell", 2),
-        ],
-    )
-    def test_get(self, cell_0_0: PatchCell, attr, target, expected):
-        """Test getting values."""
-        # arrange
-        actor = cell_0_0.agents.new(Actor, singleton=True)
-        cell_0_0.test2 = 2
-        actor.test2 = 3
-        # act
-        value = actor.get(attr=attr, target=target)
-        # assert
-        assert value == expected
-
-    @pytest.mark.parametrize(
-        "attr, target, value",
-        [
-            ("test", "actor", 1),
-            ("test", None, "testing text"),
-            ("test", "actor", ["test", "test1", "test2"]),
-        ],
-    )
-    def test_set(self, cell_0_0: PatchCell, attr, value, target):
-        """Test setting values."""
-        # arrange
-        actor = cell_0_0.agents.new(Actor, singleton=True)
-        actor.test = 0
-        # act
-        actor.set(attr=attr, value=value, target=target)
-        # assert
-        assert getattr(actor, attr) == value
-
-    @pytest.mark.parametrize(
         "attr, target, value",
         [
             ("test1", "cell", 1),
@@ -163,3 +126,48 @@ class TestCustomizedActor:
         assert man.speak() is None, "Dead man speaks! Crazy."
         assert man.get() is None
         assert isinstance(man.speak_bad(), str)
+
+
+class TestGettingValues:
+    """Test getting values."""
+
+    @pytest.mark.parametrize(
+        "attr, target, expected",
+        [
+            ("test2", None, 3),
+            ("test2", "actor", 3),
+            ("test2", "cell", 2),
+        ],
+    )
+    def test_get_happy_path(self, cell_0_0: PatchCell, attr, target, expected):
+        """Test getting values."""
+        # arrange
+        actor = cell_0_0.agents.new(Actor, singleton=True)
+        cell_0_0.test2 = 2
+        actor.test2 = 3
+        # act
+        value = actor.get(attr=attr, target=target)
+        # assert
+        assert value == expected
+
+
+class TestSettingValues:
+    """Test setting values."""
+
+    @pytest.mark.parametrize(
+        "attr, target, value",
+        [
+            ("test", "actor", 1),
+            ("test", None, "testing text"),
+            ("test", "actor", ["test", "test1", "test2"]),
+        ],
+    )
+    def test_set_happy_path(self, cell_0_0: PatchCell, attr, value, target):
+        """Test setting values."""
+        # arrange
+        actor = cell_0_0.agents.new(Actor, singleton=True)
+        actor.test = 0
+        # act
+        actor.set(attr=attr, value=value, target=target)
+        # assert
+        assert getattr(actor, attr) == value

--- a/tests/api/test_actor.py
+++ b/tests/api/test_actor.py
@@ -201,3 +201,33 @@ class TestSettingValues:
         actor.set(attr=attr, value=value, target=target)
         # assert
         assert getattr(actor, attr) == value
+
+    @pytest.mark.parametrize(
+        "attr, target, error, msg",
+        [
+            ("test2", None, AttributeError, "no attribute 'test2'"),
+            ("test2", "cell", AttributeError, "no attribute 'test2'"),
+            ("test2", "actor", AttributeError, "no attribute 'test2'"),
+            (
+                "test",
+                "not_a_target",
+                AssertionError,
+                "already has attr 'test'",
+            ),
+            ("test2", "not_a_target", ABSESpyError, "Unknown target"),
+            ("test2", "linking", AttributeError, "no attribute 'test2'"),
+            ("_test", "linking", ABSESpyError, "is protected"),
+        ],
+    )
+    def test_set_wrong(self, cell_0_0: PatchCell, attr, target, error, msg):
+        """Testing getting values in batch.
+        When the target is None, the agent itself is the target.
+        """
+        # arrange
+        actor1 = cell_0_0.agents.new(Actor, singleton=True)
+        actor1.link.to(cell_0_0, "linking")
+        actor1.test = 1
+        cell_0_0.test = 2
+        # act / assert
+        with pytest.raises(error, match=msg):
+            actor1.set(attr, 3, target=target)


### PR DESCRIPTION
## Fixed bugs

- [x] #bug🐛 Fixing default getter setter for `ActorsList`, `Actor`, and `PatchCell`
- [x] #bug🐛  AttributeError when getting value with wrong key

## Documentation changes

- [x] #docs📄 adding authors' ORCID of the paper
- [x] #docs📄 correcting installation from source tutorial
- [x] #docs📄  fixing Mantilla Ibarra name and capitalizing refers