### PR TITLE
fix(agents): :bug: Swap ActorsList base order to fix mesa 3.5 MRO error

### DIFF
--- a/abses/agents/sequences.py
+++ b/abses/agents/sequences.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from abses.core.types import HOW_TO_SELECT
 
 
-class ActorsList(Generic[A], AgentSet):
+class ActorsList(AgentSet, Generic[A]):
     """Extended agent set specifically designed for managing Actor collections.
 
     ActorsList extends Mesa's AgentSet with ABSESpy-specific functionality, providing

--- a/tests/api/test_actorslist_mesa_compat.py
+++ b/tests/api/test_actorslist_mesa_compat.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*-coding:utf-8 -*-
+"""Regression tests for ActorsList vs mesa AgentSet MRO.
+
+mesa 3.5 added ``typing.Generic`` to ``AgentSet.__bases__``. If ``ActorsList``
+is declared as ``class ActorsList(Generic[A], AgentSet)`` Python cannot
+linearize the MRO and ``import abses`` fails. Keep ``AgentSet`` first to stay
+compatible across mesa 3.1–3.5+.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from mesa.agent import AgentSet
+
+
+def test_actorslist_subclasses_agentset() -> None:
+    """ActorsList must remain a real AgentSet subclass."""
+    from abses.agents.sequences import ActorsList
+
+    assert issubclass(ActorsList, AgentSet)
+
+
+def test_actorslist_stays_generic() -> None:
+    """Generic parameterization ``ActorsList[Actor]`` must still work."""
+    from abses.agents.actor import Actor
+    from abses.agents.sequences import ActorsList
+
+    parameterized = ActorsList[Actor]
+    assert typing.get_origin(parameterized) is ActorsList
+
+
+def test_agentset_first_in_bases() -> None:
+    """Guard against regressing to ``(Generic[A], AgentSet)`` base order."""
+    from abses.agents.sequences import ActorsList
+
+    assert ActorsList.__bases__[0] is AgentSet


### PR DESCRIPTION
mesa 3.5 added typing.Generic to AgentSet's bases, so declaring ActorsList as (Generic[A], AgentSet) made the MRO unlinearizable and broke `import abses`. Put AgentSet first to stay compatible with mesa 3.1-3.5+, and add regression tests guarding the base order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to validate API compatibility with Mesa AgentSet across versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->